### PR TITLE
Fix metadata retrieval call

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import calendar
 from collections import defaultdict
 from dataclasses import dataclass
+from functools import partial
 from datetime import date, datetime, time, timedelta
 import logging
 from pathlib import Path
@@ -295,9 +296,7 @@ async def _collect_statistics(
         ) from err
 
     metadata = await instance.async_add_executor_job(
-        recorder_statistics.get_metadata,
-        hass,
-        statistic_ids=statistic_ids,
+        partial(recorder_statistics.get_metadata, hass, statistic_ids)
     )
 
     stats_map = await instance.async_add_executor_job(


### PR DESCRIPTION
## Summary
- wrap the recorder statistics metadata call in a partial so the executor job uses positional arguments
- add the functools import required for the new helper

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d2c6bf7e1c8320b8f1a660c88d8d0e