### PR TITLE
Set default options during config flow

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -38,7 +38,17 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_reinstall_confirm(user_input)
 
         if user_input is not None:
-            return self.async_create_entry(title="Rapport PDF Énergie", data={})
+            default_options = {
+                CONF_OUTPUT_DIR: DEFAULT_OUTPUT_DIR,
+                CONF_FILENAME_PATTERN: DEFAULT_FILENAME_PATTERN,
+                CONF_DEFAULT_REPORT_TYPE: DEFAULT_REPORT_TYPE,
+            }
+
+            return self.async_create_entry(
+                title="Rapport PDF Énergie",
+                data={},
+                options=default_options,
+            )
 
         return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
 
@@ -77,7 +87,17 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_current_entries():
             return self.async_abort(reason="already_configured")
 
-        return self.async_create_entry(title="Rapport PDF Énergie", data={})
+        default_options = {
+            CONF_OUTPUT_DIR: DEFAULT_OUTPUT_DIR,
+            CONF_FILENAME_PATTERN: DEFAULT_FILENAME_PATTERN,
+            CONF_DEFAULT_REPORT_TYPE: DEFAULT_REPORT_TYPE,
+        }
+
+        return self.async_create_entry(
+            title="Rapport PDF Énergie",
+            data={},
+            options=default_options,
+        )
 
 
 


### PR DESCRIPTION
## Summary
- populate newly created config entries with the integration's default options
- ensure both user-initiated and YAML-imported entries store default output, filename, and report type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d682742270832087a4735ebe2e89e2