### PR TITLE
docs: add hacs installation and configuration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# test2codex
-anothercodextest
+# EcoPilot PDF Report
+
+Generate PDF energy reports directly from your Home Assistant instance using the EcoPilot PDF Report custom integration.
+
+## Installation via HACS
+
+1. Confirm that [HACS](https://hacs.xyz/) is installed and configured in your Home Assistant instance.
+2. Navigate to **HACS → Integrations** and select the overflow menu (⋮) in the top-right corner.
+3. Choose **Custom repositories**, enter the GitHub URL for this repository (for example, `https://github.com/OWNER/ecopilot-pdf-report`), and set the category to **Integration**.
+4. Click **Add** to register the repository and close the dialog.
+5. Back in **HACS → Integrations**, search for **EcoPilot PDF Report** and select it.
+6. Click **Download** and follow the prompts to install the integration, then restart Home Assistant if prompted.
+7. After Home Assistant reloads, open **Settings → Integrations**, click **Add Integration**, search for **EcoPilot PDF Report**, and complete the setup so it appears in your integrations list.
+
+## Configuration
+
+The integration exposes three configurable options that can be adjusted from the integration entry's **Options** dialog in Home Assistant:
+
+- `output_dir`: Directory where generated PDF reports are stored.
+- `filename_pattern`: Template used to name generated PDF files.
+- `default_report_type`: Report type selected by default when generating PDFs.
+
+You can revisit the integration options at any time via **Settings → Devices & Services → EcoPilot PDF Report → Configure** to update these values.
+
+## Triggering the service
+
+The integration provides the `energy_pdf_report.generate_report` service. You can trigger it from **Developer Tools → Services** or via YAML automation as shown below:
+
+```yaml
+service: energy_pdf_report.generate_report
+data:
+  report_type: daily
+  start_date: "2024-01-01"
+  end_date: "2024-01-07"
+  output_dir: "/config/www/reports"
+  filename: "weekly_energy_report.pdf"
+```
+
+Adjust the parameters to suit your environment or omit optional fields to rely on the configured defaults.


### PR DESCRIPTION
## Summary
- expand the README with detailed HACS installation steps for the integration
- document configurable options available in the integration options dialog
- add a YAML example demonstrating how to trigger the energy_pdf_report.generate_report service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6827bb4ac8320850b01a8f42bab02