### PR TITLE
Add CO₂ summary section to energy PDF report

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -16,6 +16,7 @@ from typing import Any, Iterable, TYPE_CHECKING
 import voluptuous as vol
 
 from homeassistant.components import persistent_notification, recorder
+from homeassistant.components.recorder import history as recorder_history
 from homeassistant.components.recorder import statistics as recorder_statistics
 from homeassistant.components.recorder.models.statistics import StatisticMetaData
 from homeassistant.components.recorder.statistics import StatisticsRow
@@ -86,6 +87,16 @@ class MetricDefinition:
 
     category: str
     statistic_id: str
+
+
+
+@dataclass(frozen=True, slots=True)
+class CO2SensorDefinition:
+    """Décrit un capteur CO₂ suivi dans le rapport."""
+
+    entity_id: str
+    translation_key: str
+    is_saving: bool
 
 
 
@@ -202,6 +213,30 @@ _ALLOWED_OPTION_KEYS: tuple[str, ...] = (
 )
 
 
+CO2_SENSOR_DEFINITIONS: tuple[CO2SensorDefinition, ...] = (
+    CO2SensorDefinition(
+        "sensor.ecopilot_co2_electricity",
+        "co2_electricity",
+        False,
+    ),
+    CO2SensorDefinition(
+        "sensor.ecopilot_co2_mazout",
+        "co2_mazout",
+        False,
+    ),
+    CO2SensorDefinition(
+        "sensor.ecopilot_co2_water",
+        "co2_water",
+        False,
+    ),
+    CO2SensorDefinition(
+        "sensor.ecopilot_co2_savings",
+        "co2_savings",
+        True,
+    ),
+)
+
+
 def _get_config_entry_options(hass: HomeAssistant) -> dict[str, Any]:
     """Fusionner data et options des entrées actives."""
 
@@ -293,6 +328,13 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
     stats_map, metadata = await _collect_statistics(hass, metrics, start, end, bucket)
     totals = _calculate_totals(metrics, stats_map)
 
+    co2_totals = await _collect_co2_statistics(
+        hass,
+        start,
+        end,
+        CO2_SENSOR_DEFINITIONS,
+    )
+
     output_dir_input = call.data.get(
         CONF_OUTPUT_DIR, options.get(CONF_OUTPUT_DIR, DEFAULT_OUTPUT_DIR)
     )
@@ -335,6 +377,9 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
         period,
 
         translations,
+
+        CO2_SENSOR_DEFINITIONS,
+        co2_totals,
     )
 
     message_lines = [
@@ -944,6 +989,87 @@ async def _collect_statistics(
     return stats_map, metadata
 
 
+async def _collect_co2_statistics(
+    hass: HomeAssistant,
+    start: datetime,
+    end: datetime,
+    sensors: Iterable[CO2SensorDefinition],
+) -> dict[str, float]:
+    """Assembler les totaux CO₂ sur la période demandée."""
+
+    definitions = list(sensors)
+    results: dict[str, float] = {
+        definition.translation_key: 0.0 for definition in definitions
+    }
+
+    if not definitions:
+        return results
+
+    entity_map = {definition.entity_id: definition for definition in definitions}
+    statistic_ids = list(entity_map)
+
+    instance = recorder.get_instance(hass)
+
+    stats_map = await instance.async_add_executor_job(
+        recorder_statistics.statistics_during_period,
+        hass,
+        start,
+        end,
+        statistic_ids,
+        "day",
+        None,
+        {"sum"},
+    )
+
+    need_history: list[str] = []
+
+    for entity_id in statistic_ids:
+        rows = stats_map.get(entity_id)
+        if not rows:
+            need_history.append(entity_id)
+            continue
+
+        total = 0.0
+        has_sum = False
+        for row in rows:
+            sum_value = row.get("sum")
+            if sum_value is None:
+                continue
+            has_sum = True
+            total += float(sum_value)
+
+        if has_sum:
+            definition = entity_map[entity_id]
+            results[definition.translation_key] = total
+        else:
+            need_history.append(entity_id)
+
+    if need_history:
+        history_map = await instance.async_add_executor_job(
+            recorder_history.state_changes_during_period,
+            hass,
+            start,
+            end,
+            need_history,
+        )
+
+        for entity_id, states in history_map.items():
+            definition = entity_map.get(entity_id)
+            if not definition:
+                continue
+
+            total = 0.0
+            for state in states:
+                value = _safe_float(state.state)
+                if value is None:
+                    continue
+                total += value
+
+            results[definition.translation_key] = total
+
+    return results
+
+
 def _get_recorder_metadata_with_hass(
     hass: HomeAssistant,
     statistic_ids: set[str],
@@ -1047,6 +1173,9 @@ def _build_pdf(
     period: str,
 
     translations: ReportTranslations,
+
+    co2_definitions: Iterable[CO2SensorDefinition],
+    co2_totals: dict[str, float],
 
 ) -> str:
     """Assembler le PDF et le sauvegarder sur disque."""
@@ -1162,6 +1291,56 @@ def _build_pdf(
         builder.add_paragraph(translations.chart_intro)
         builder.add_chart(translations.chart_title, summary_series)
 
+    totals_map = co2_totals or {}
+    builder.add_section_title(translations.co2_section_title)
+    builder.add_paragraph(translations.co2_section_intro)
+
+    co2_rows: list[tuple[str, str, str]] = []
+    emissions_total = 0.0
+    savings_total = 0.0
+
+    for definition in co2_definitions:
+        value = totals_map.get(definition.translation_key)
+        if value is None:
+            continue
+
+        label = translations.co2_sensor_labels.get(
+            definition.translation_key, definition.translation_key
+        )
+        formatted_value = _format_number(value)
+        impact_label = (
+            translations.co2_savings_label
+            if definition.is_saving
+            else translations.co2_emission_label
+        )
+        co2_rows.append((label, f"{formatted_value} kgCO₂e", impact_label))
+
+        if definition.is_saving:
+            savings_total += value
+        else:
+            emissions_total += value
+
+    co2_widths = builder.compute_column_widths((0.5, 0.28, 0.22))
+    builder.add_table(
+        TableConfig(
+            title=translations.co2_table_title,
+            headers=translations.co2_table_headers,
+            rows=co2_rows,
+            column_widths=co2_widths,
+        )
+    )
+
+    if co2_rows:
+        balance = emissions_total - savings_total
+        builder.add_paragraph(
+            translations.co2_balance_sentence.format(
+                emissions=f"{_format_number(emissions_total)} kgCO₂e",
+                savings=f"{_format_number(savings_total)} kgCO₂e",
+                balance=f"{_format_number(balance)} kgCO₂e",
+            ),
+            bold=True,
+        )
+
     builder.add_section_title(translations.conclusion_title)
 
 
@@ -1273,6 +1452,15 @@ def _extract_name(
     if metadata and metadata[1].get("name"):
         return str(metadata[1]["name"])
     return fallback
+
+
+def _safe_float(value: Any) -> float | None:
+    """Convertir une valeur en flottant si possible."""
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _format_number(value: float) -> str:

--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -33,6 +33,14 @@ class ReportTranslations:
     chart_intro: str
     chart_title: str
     chart_units: str
+    co2_section_title: str
+    co2_section_intro: str
+    co2_table_title: str
+    co2_table_headers: tuple[str, str, str]
+    co2_emission_label: str
+    co2_savings_label: str
+    co2_balance_sentence: str
+    co2_sensor_labels: Mapping[str, str]
     conclusion_title: str
     conclusion_total: str
     conclusion_dominant: str
@@ -72,6 +80,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         chart_intro="La visualisation suivante met en avant la répartition des flux pour chaque catégorie suivie et matérialise l'équilibre production / consommation.",
         chart_title="Répartition par catégorie",
         chart_units="Unités : {unit}",
+        co2_section_title="CO₂",
+        co2_section_intro="Cette section met en lumière les émissions et économies de CO₂ enregistrées par les différents postes.",
+        co2_table_title="Émissions et économies de CO₂",
+        co2_table_headers=("Source", "Total (kgCO₂e)", "Impact"),
+        co2_emission_label="Émission",
+        co2_savings_label="Économie",
+        co2_balance_sentence="Émissions totales : {emissions} • Économies : {savings} • Bilan net : {balance}.",
+        co2_sensor_labels={
+            "co2_electricity": "Électricité",
+            "co2_mazout": "Mazout",
+            "co2_water": "Eau chaude sanitaire",
+            "co2_savings": "Économies / compensation",
+        },
         conclusion_title="Conclusion",
         conclusion_total="Le flux net observé sur la période atteint {total}.",
         conclusion_dominant="La catégorie la plus significative est {category} avec {value}.",
@@ -109,6 +130,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         chart_intro="The following chart highlights the distribution of flows per category and illustrates the production versus consumption balance.",
         chart_title="Breakdown by category",
         chart_units="Units: {unit}",
+        co2_section_title="CO₂",
+        co2_section_intro="This section summarises the CO₂ emissions and savings reported by your sensors.",
+        co2_table_title="CO₂ emissions and savings",
+        co2_table_headers=("Source", "Total (kgCO₂e)", "Impact"),
+        co2_emission_label="Emission",
+        co2_savings_label="Saving",
+        co2_balance_sentence="Total emissions: {emissions} • Savings: {savings} • Net balance: {balance}.",
+        co2_sensor_labels={
+            "co2_electricity": "Electricity",
+            "co2_mazout": "Heating oil",
+            "co2_water": "Domestic hot water",
+            "co2_savings": "Savings / offset",
+        },
         conclusion_title="Conclusion",
         conclusion_total="The net flow observed over the period is {total}.",
         conclusion_dominant="The most significant category is {category} with {value}.",
@@ -146,6 +180,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         chart_intro="De volgende visualisatie toont de verdeling van de stromen per categorie en beeldt het evenwicht tussen productie en verbruik uit.",
         chart_title="Verdeling per categorie",
         chart_units="Eenheden: {unit}",
+        co2_section_title="CO₂",
+        co2_section_intro="Deze sectie toont de door uw sensoren geregistreerde CO₂-uitstoot en besparingen.",
+        co2_table_title="CO₂-uitstoot en besparingen",
+        co2_table_headers=("Bron", "Totaal (kgCO₂e)", "Impact"),
+        co2_emission_label="Uitstoot",
+        co2_savings_label="Besparing",
+        co2_balance_sentence="Totale uitstoot: {emissions} • Besparingen: {savings} • Nettoresultaat: {balance}.",
+        co2_sensor_labels={
+            "co2_electricity": "Elektriciteit",
+            "co2_mazout": "Stookolie",
+            "co2_water": "Sanitair warm water",
+            "co2_savings": "Besparingen / compensatie",
+        },
         conclusion_title="Conclusie",
         conclusion_total="De netto stroom over de periode bedraagt {total}.",
         conclusion_dominant="De meest bepalende categorie is {category} met {value}.",


### PR DESCRIPTION
## Summary
- add carbon sensor definitions and aggregation logic so the report can collect daily CO₂ totals, even when statistics sums are missing
- inject the aggregated CO₂ metrics into the PDF builder and render a dedicated section with per-sensor totals and balance messaging
- extend the translation catalog with localized CO₂ section strings and sensor labels for all supported languages

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d7d91ba35483208f3ced399bb2ff4f