### PR TITLE
Add CO₂ summary section to energy PDF report

### DIFF
--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -33,6 +33,14 @@ class ReportTranslations:
     chart_intro: str
     chart_title: str
     chart_units: str
+    co2_section_title: str
+    co2_section_intro: str
+    co2_table_title: str
+    co2_table_headers: tuple[str, str, str]
+    co2_emission_label: str
+    co2_savings_label: str
+    co2_balance_sentence: str
+    co2_sensor_labels: Mapping[str, str]
     conclusion_title: str
     conclusion_total: str
     conclusion_dominant: str
@@ -72,6 +80,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         chart_intro="La visualisation suivante met en avant la répartition des flux pour chaque catégorie suivie et matérialise l'équilibre production / consommation.",
         chart_title="Répartition par catégorie",
         chart_units="Unités : {unit}",
+        co2_section_title="CO₂",
+        co2_section_intro="Cette section met en lumière les émissions et économies de CO₂ enregistrées par les différents postes.",
+        co2_table_title="Émissions et économies de CO₂",
+        co2_table_headers=("Source", "Total (kgCO₂e)", "Impact"),
+        co2_emission_label="Émission",
+        co2_savings_label="Économie",
+        co2_balance_sentence="Émissions totales : {emissions} • Économies : {savings} • Bilan net : {balance}.",
+        co2_sensor_labels={
+            "co2_electricity": "Électricité (scope 2)",
+            "co2_gas": "Gaz",
+            "co2_water": "Eau",
+            "co2_savings": "Économies solaire (autoconsommation)",
+        },
         conclusion_title="Conclusion",
         conclusion_total="Le flux net observé sur la période atteint {total}.",
         conclusion_dominant="La catégorie la plus significative est {category} avec {value}.",
@@ -109,6 +130,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         chart_intro="The following chart highlights the distribution of flows per category and illustrates the production versus consumption balance.",
         chart_title="Breakdown by category",
         chart_units="Units: {unit}",
+        co2_section_title="CO₂",
+        co2_section_intro="This section summarises the CO₂ emissions and savings reported by your sensors.",
+        co2_table_title="CO₂ emissions and savings",
+        co2_table_headers=("Source", "Total (kgCO₂e)", "Impact"),
+        co2_emission_label="Emission",
+        co2_savings_label="Saving",
+        co2_balance_sentence="Total emissions: {emissions} • Savings: {savings} • Net balance: {balance}.",
+        co2_sensor_labels={
+            "co2_electricity": "Electricity (scope 2)",
+            "co2_gas": "Gas",
+            "co2_water": "Water",
+            "co2_savings": "Solar self-consumption savings",
+        },
         conclusion_title="Conclusion",
         conclusion_total="The net flow observed over the period is {total}.",
         conclusion_dominant="The most significant category is {category} with {value}.",
@@ -146,6 +180,19 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         chart_intro="De volgende visualisatie toont de verdeling van de stromen per categorie en beeldt het evenwicht tussen productie en verbruik uit.",
         chart_title="Verdeling per categorie",
         chart_units="Eenheden: {unit}",
+        co2_section_title="CO₂",
+        co2_section_intro="Deze sectie toont de door uw sensoren geregistreerde CO₂-uitstoot en besparingen.",
+        co2_table_title="CO₂-uitstoot en besparingen",
+        co2_table_headers=("Bron", "Totaal (kgCO₂e)", "Impact"),
+        co2_emission_label="Uitstoot",
+        co2_savings_label="Besparing",
+        co2_balance_sentence="Totale uitstoot: {emissions} • Besparingen: {savings} • Nettoresultaat: {balance}.",
+        co2_sensor_labels={
+            "co2_electricity": "Elektriciteit (scope 2)",
+            "co2_gas": "Gas",
+            "co2_water": "Water",
+            "co2_savings": "Zonnebesparing (eigen verbruik)",
+        },
         conclusion_title="Conclusie",
         conclusion_total="De netto stroom over de periode bedraagt {total}.",
         conclusion_dominant="De meest bepalende categorie is {category} met {value}.",


### PR DESCRIPTION
## Summary
- add carbon sensor definitions covering the daily electricity, gas, water, and solar-saving sensors and aggregate CO₂ totals even when statistics sums are missing
- inject the aggregated CO₂ metrics into the PDF builder and render a dedicated section with per-sensor totals and balance messaging
- extend the translation catalog with localized CO₂ section strings and sensor labels for all supported languages
- fix the CO₂ history fallback by querying recorder per-entity so generation continues when statistics are unavailable

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d7d91ba35483208f3ced399bb2ff4f