### PR TITLE
Add CO₂ sensor configuration to setup and options flows

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, tzinfo
 
 from pathlib import Path
-from typing import Any, Iterable, TYPE_CHECKING
+from typing import Any, Iterable, Mapping, TYPE_CHECKING
 
 import voluptuous as vol
 
@@ -32,6 +32,10 @@ from homeassistant.util import dt as dt_util
 from homeassistant.components.energy.data import async_get_manager
 
 from .const import (
+    CONF_CO2_ELECTRICITY,
+    CONF_CO2_GAS,
+    CONF_CO2_SAVINGS,
+    CONF_CO2_WATER,
     CONF_DASHBOARD,
     CONF_DEFAULT_REPORT_TYPE,
     CONF_END_DATE,
@@ -40,6 +44,10 @@ from .const import (
     CONF_PERIOD,
     CONF_START_DATE,
     CONF_LANGUAGE,
+    DEFAULT_CO2_ELECTRICITY_SENSOR,
+    DEFAULT_CO2_GAS_SENSOR,
+    DEFAULT_CO2_SAVINGS_SENSOR,
+    DEFAULT_CO2_WATER_SENSOR,
     DEFAULT_FILENAME_PATTERN,
     DEFAULT_OUTPUT_DIR,
     DEFAULT_LANGUAGE,
@@ -210,37 +218,71 @@ _ALLOWED_OPTION_KEYS: tuple[str, ...] = (
 
     CONF_LANGUAGE,
 
+    CONF_CO2_ELECTRICITY,
+    CONF_CO2_GAS,
+    CONF_CO2_WATER,
+    CONF_CO2_SAVINGS,
+
 )
 
 
 CO2_SENSOR_DEFINITIONS: tuple[CO2SensorDefinition, ...] = (
     CO2SensorDefinition(
-
-        "sensor.co2_scope_2_electricite_co2_prod_daily_precis",
-
+        DEFAULT_CO2_ELECTRICITY_SENSOR,
         "co2_electricity",
         False,
     ),
     CO2SensorDefinition(
-
-        "sensor.co2_gaz_jour",
+        DEFAULT_CO2_GAS_SENSOR,
         "co2_gas",
         False,
     ),
     CO2SensorDefinition(
-        "sensor.co2_eau_jour",
-
+        DEFAULT_CO2_WATER_SENSOR,
         "co2_water",
         False,
     ),
     CO2SensorDefinition(
-
-        "sensor.co2_savings_today",
-
+        DEFAULT_CO2_SAVINGS_SENSOR,
         "co2_savings",
         True,
     ),
 )
+
+_CO2_SENSOR_OPTION_DEFAULTS: tuple[tuple[str, str], ...] = (
+    (CONF_CO2_ELECTRICITY, DEFAULT_CO2_ELECTRICITY_SENSOR),
+    (CONF_CO2_GAS, DEFAULT_CO2_GAS_SENSOR),
+    (CONF_CO2_WATER, DEFAULT_CO2_WATER_SENSOR),
+    (CONF_CO2_SAVINGS, DEFAULT_CO2_SAVINGS_SENSOR),
+)
+
+
+def _build_co2_sensor_definitions(
+    options: Mapping[str, Any]
+) -> tuple[CO2SensorDefinition, ...]:
+    """Return CO₂ sensor definitions, including user overrides."""
+
+    definitions: list[CO2SensorDefinition] = []
+
+    for base_definition, (option_key, default_entity) in zip(
+        CO2_SENSOR_DEFINITIONS, _CO2_SENSOR_OPTION_DEFAULTS, strict=True
+    ):
+        override = options.get(option_key)
+        entity_id = (
+            override.strip()
+            if isinstance(override, str) and override.strip()
+            else default_entity
+        )
+
+        definitions.append(
+            CO2SensorDefinition(
+                entity_id,
+                base_definition.translation_key,
+                base_definition.is_saving,
+            )
+        )
+
+    return tuple(definitions)
 
 
 def _get_config_entry_options(hass: HomeAssistant) -> dict[str, Any]:
@@ -334,11 +376,13 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
     stats_map, metadata = await _collect_statistics(hass, metrics, start, end, bucket)
     totals = _calculate_totals(metrics, stats_map)
 
+    co2_definitions = _build_co2_sensor_definitions(options)
+
     co2_totals = await _collect_co2_statistics(
         hass,
         start,
         end,
-        CO2_SENSOR_DEFINITIONS,
+        co2_definitions,
     )
 
     output_dir_input = call.data.get(
@@ -384,7 +428,7 @@ async def _async_handle_generate(hass: HomeAssistant, call: ServiceCall) -> None
 
         translations,
 
-        CO2_SENSOR_DEFINITIONS,
+        co2_definitions,
         co2_totals,
     )
 

--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -10,10 +10,18 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
+    CONF_CO2_ELECTRICITY,
+    CONF_CO2_GAS,
+    CONF_CO2_SAVINGS,
+    CONF_CO2_WATER,
     CONF_DEFAULT_REPORT_TYPE,
     CONF_FILENAME_PATTERN,
     CONF_OUTPUT_DIR,
     CONF_LANGUAGE,
+    DEFAULT_CO2_ELECTRICITY_SENSOR,
+    DEFAULT_CO2_GAS_SENSOR,
+    DEFAULT_CO2_SAVINGS_SENSOR,
+    DEFAULT_CO2_WATER_SENSOR,
     DEFAULT_FILENAME_PATTERN,
     DEFAULT_OUTPUT_DIR,
     DEFAULT_REPORT_TYPE,
@@ -49,6 +57,10 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_FILENAME_PATTERN, default=DEFAULT_FILENAME_PATTERN): cv.string,
                 vol.Required(CONF_DEFAULT_REPORT_TYPE, default=DEFAULT_REPORT_TYPE): vol.In(VALID_REPORT_TYPES),
                 vol.Required(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): vol.In(SUPPORTED_LANGUAGES),
+                vol.Required(CONF_CO2_ELECTRICITY, default=DEFAULT_CO2_ELECTRICITY_SENSOR): cv.entity_id,
+                vol.Required(CONF_CO2_GAS, default=DEFAULT_CO2_GAS_SENSOR): cv.entity_id,
+                vol.Required(CONF_CO2_WATER, default=DEFAULT_CO2_WATER_SENSOR): cv.entity_id,
+                vol.Required(CONF_CO2_SAVINGS, default=DEFAULT_CO2_SAVINGS_SENSOR): cv.entity_id,
             }
         )
 
@@ -71,6 +83,7 @@ class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
 
         data = dict(self.config_entry.data)  # 👉 récupérer les valeurs de base
+        data.update(self.config_entry.options)
 
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
@@ -81,6 +94,10 @@ class EnergyPDFReportOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(CONF_FILENAME_PATTERN, default=data.get(CONF_FILENAME_PATTERN, DEFAULT_FILENAME_PATTERN)): cv.string,
                 vol.Required(CONF_DEFAULT_REPORT_TYPE, default=data.get(CONF_DEFAULT_REPORT_TYPE, DEFAULT_REPORT_TYPE)): vol.In(VALID_REPORT_TYPES),
                 vol.Required(CONF_LANGUAGE, default=data.get(CONF_LANGUAGE, DEFAULT_LANGUAGE)): vol.In(SUPPORTED_LANGUAGES),
+                vol.Required(CONF_CO2_ELECTRICITY, default=data.get(CONF_CO2_ELECTRICITY, DEFAULT_CO2_ELECTRICITY_SENSOR)): cv.entity_id,
+                vol.Required(CONF_CO2_GAS, default=data.get(CONF_CO2_GAS, DEFAULT_CO2_GAS_SENSOR)): cv.entity_id,
+                vol.Required(CONF_CO2_WATER, default=data.get(CONF_CO2_WATER, DEFAULT_CO2_WATER_SENSOR)): cv.entity_id,
+                vol.Required(CONF_CO2_SAVINGS, default=data.get(CONF_CO2_SAVINGS, DEFAULT_CO2_SAVINGS_SENSOR)): cv.entity_id,
             }
         )
 

--- a/custom_components/energy_pdf_report/const.py
+++ b/custom_components/energy_pdf_report/const.py
@@ -25,5 +25,15 @@ CONF_DEFAULT_REPORT_TYPE = "default_report_type"
 
 CONF_LANGUAGE = "language"
 
+CONF_CO2_ELECTRICITY = "co2_sensor_electricity"
+CONF_CO2_GAS = "co2_sensor_gas"
+CONF_CO2_WATER = "co2_sensor_water"
+CONF_CO2_SAVINGS = "co2_sensor_savings"
+
+DEFAULT_CO2_ELECTRICITY_SENSOR = "sensor.co2_scope_2_electricite_co2_prod_daily_precis"
+DEFAULT_CO2_GAS_SENSOR = "sensor.co2_gaz_jour"
+DEFAULT_CO2_WATER_SENSOR = "sensor.co2_eau_jour"
+DEFAULT_CO2_SAVINGS_SENSOR = "sensor.co2_savings_today"
+
 
 PDF_TITLE = "Rapport énergie"

--- a/custom_components/energy_pdf_report/translations/en.json
+++ b/custom_components/energy_pdf_report/translations/en.json
@@ -1,7 +1,20 @@
 {
-
   "config": {
     "step": {
+      "user": {
+        "data": {
+          "co2_sensor_electricity": "Electricity CO₂ sensor",
+          "co2_sensor_gas": "Gas CO₂ sensor",
+          "co2_sensor_water": "Water CO₂ sensor",
+          "co2_sensor_savings": "Savings CO₂ sensor"
+        },
+        "data_description": {
+          "co2_sensor_electricity": "Entity ID providing electricity emissions statistics (default: sensor.co2_scope_2_electricite_co2_prod_daily_precis).",
+          "co2_sensor_gas": "Entity ID providing gas emissions statistics (default: sensor.co2_gaz_jour).",
+          "co2_sensor_water": "Entity ID providing water emissions statistics (default: sensor.co2_eau_jour).",
+          "co2_sensor_savings": "Entity ID providing CO₂ savings statistics (default: sensor.co2_savings_today)."
+        }
+      },
       "reinstall_confirm": {
         "title": "Replace existing Energy PDF Report",
         "description": "An existing Energy PDF Report configuration ({title}) was found. Submit to remove it and install it again."
@@ -12,14 +25,23 @@
       "already_configured": "Energy PDF Report is already configured."
     }
   },
-
   "options": {
     "step": {
       "init": {
-
         "title": "Energy PDF Report options",
-        "description": "Configure the default output directory, reporting period and filename pattern used when generating PDFs."
-
+        "description": "Configure the default output directory, reporting period and filename pattern used when generating PDFs.",
+        "data": {
+          "co2_sensor_electricity": "Electricity CO₂ sensor",
+          "co2_sensor_gas": "Gas CO₂ sensor",
+          "co2_sensor_water": "Water CO₂ sensor",
+          "co2_sensor_savings": "Savings CO₂ sensor"
+        },
+        "data_description": {
+          "co2_sensor_electricity": "Entity ID providing electricity emissions statistics (default: sensor.co2_scope_2_electricite_co2_prod_daily_precis).",
+          "co2_sensor_gas": "Entity ID providing gas emissions statistics (default: sensor.co2_gaz_jour).",
+          "co2_sensor_water": "Entity ID providing water emissions statistics (default: sensor.co2_eau_jour).",
+          "co2_sensor_savings": "Entity ID providing CO₂ savings statistics (default: sensor.co2_savings_today)."
+        }
       }
     }
   }

--- a/custom_components/energy_pdf_report/translations/fr.json
+++ b/custom_components/energy_pdf_report/translations/fr.json
@@ -1,7 +1,20 @@
 {
-
   "config": {
     "step": {
+      "user": {
+        "data": {
+          "co2_sensor_electricity": "Capteur CO₂ électricité",
+          "co2_sensor_gas": "Capteur CO₂ gaz",
+          "co2_sensor_water": "Capteur CO₂ eau",
+          "co2_sensor_savings": "Capteur économies de CO₂"
+        },
+        "data_description": {
+          "co2_sensor_electricity": "Identifiant de l'entité fournissant les émissions d'électricité (par défaut : sensor.co2_scope_2_electricite_co2_prod_daily_precis).",
+          "co2_sensor_gas": "Identifiant de l'entité fournissant les émissions de gaz (par défaut : sensor.co2_gaz_jour).",
+          "co2_sensor_water": "Identifiant de l'entité fournissant les émissions liées à l'eau (par défaut : sensor.co2_eau_jour).",
+          "co2_sensor_savings": "Identifiant de l'entité indiquant les économies de CO₂ (par défaut : sensor.co2_savings_today)."
+        }
+      },
       "reinstall_confirm": {
         "title": "Remplacer la configuration existante",
         "description": "Une configuration Energy PDF Report (« {title} ») est déjà présente. Validez pour la supprimer et la réinstaller."
@@ -12,14 +25,23 @@
       "already_configured": "Energy PDF Report est déjà configuré."
     }
   },
-
   "options": {
     "step": {
       "init": {
-
         "title": "Options du rapport PDF énergie",
-        "description": "Définissez le répertoire de sortie, la période par défaut et le modèle de nom de fichier utilisés lors de la génération des PDF."
-
+        "description": "Définissez le répertoire de sortie, la période par défaut et le modèle de nom de fichier utilisés lors de la génération des PDF.",
+        "data": {
+          "co2_sensor_electricity": "Capteur CO₂ électricité",
+          "co2_sensor_gas": "Capteur CO₂ gaz",
+          "co2_sensor_water": "Capteur CO₂ eau",
+          "co2_sensor_savings": "Capteur économies de CO₂"
+        },
+        "data_description": {
+          "co2_sensor_electricity": "Identifiant de l'entité fournissant les émissions d'électricité (par défaut : sensor.co2_scope_2_electricite_co2_prod_daily_precis).",
+          "co2_sensor_gas": "Identifiant de l'entité fournissant les émissions de gaz (par défaut : sensor.co2_gaz_jour).",
+          "co2_sensor_water": "Identifiant de l'entité fournissant les émissions liées à l'eau (par défaut : sensor.co2_eau_jour).",
+          "co2_sensor_savings": "Identifiant de l'entité indiquant les économies de CO₂ (par défaut : sensor.co2_savings_today)."
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add configurable CO₂ sensor fields to the setup and options forms with entity validation
- persist the selected CO₂ entities and use them when building statistics for the PDF report
- document the new fields in both English and French translations with default entity reminders

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68d800e136d08320ae6a0caeff1e5070