### PR TITLE
Group CO₂ history readings by local day

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1131,10 +1131,17 @@ async def _collect_co2_statistics(
                 day_key = local_changed.date()
                 previous = daily_snapshots.get(day_key)
 
-                if previous is None or local_changed >= previous[0]:
-                    daily_snapshots[day_key] = (local_changed, value)
+                if previous is not None and local_changed < previous[0]:
+                    continue
 
-            total = sum(snapshot[1] for snapshot in daily_snapshots.values())
+                daily_snapshots[day_key] = (local_changed, value)
+
+            total = 0.0
+            for _, snapshot_value in daily_snapshots.values():
+                safe_value = _safe_float(snapshot_value)
+                if safe_value is None:
+                    continue
+                total += safe_value
 
             results[definition.translation_key] = total
 


### PR DESCRIPTION
## Summary
- group CO₂ history states by their local day when statistics data is missing
- keep only the most recent reading per day and sum safely to populate totals

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d80a0b1fec832086d2e36a60e71d8f