### PR TITLE
Handle FlowResult import fallback

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -6,7 +6,10 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
+try:
+    from homeassistant.data_entry_flow import FlowResult
+except ImportError:  # pragma: no cover - compat with older versions
+    FlowResult = dict[str, Any]
 from homeassistant.helpers import config_validation as cv
 
 from .const import (


### PR DESCRIPTION
## Summary
- wrap the FlowResult import in a try/except block to maintain compatibility with older Home Assistant versions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d80a0d5dac8320ab1af5affb6aa6a7