### PR TITLE
Align config flow title with manifest name

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -58,7 +58,7 @@ class EnergyPDFReportConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             return self.async_create_entry(
-                title="Rapport PDF Énergie",
+                title="Energy PDF Report",
                 data=user_input,  # 👉 valeurs stockées directement dans data
             )
 


### PR DESCRIPTION
## Summary
- align the config flow entry title with the integration name from the manifest for consistent display in Home Assistant

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8144937dc832088bf2981af9cce9b