### PR TITLE
Allow empty CO₂ sensor selections in config flow

### DIFF
--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -61,7 +61,7 @@ def _merge_defaults(existing: Mapping[str, Any] | None = None) -> dict[str, Any]
     merged: dict[str, Any] = dict(BASE_DEFAULTS)
     if existing:
         for key, value in existing.items():
-            if value is not None:
+            if value not in (None, ""):
                 merged[key] = value
 
     return merged
@@ -83,7 +83,9 @@ def _build_schema(defaults: Mapping[str, Any]) -> vol.Schema:
     }
 
     for option_key, _ in CO2_SENSOR_DEFAULTS:
-        schema_dict[vol.Required(option_key, default=defaults[option_key])] = cv.entity_id
+        schema_dict[
+            vol.Optional(option_key, default=defaults[option_key])
+        ] = vol.Any(cv.entity_id, "", None)
 
     return vol.Schema(schema_dict)
 


### PR DESCRIPTION
## Summary
- allow the CO₂ sensor fields to be optional and accept empty values in the config flow
- avoid reusing empty CO₂ values when rebuilding defaults for the form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d932651458832088f499a465ad816b