### PR TITLE
Allow service-level toggles for CO₂ and price sections

### DIFF
--- a/custom_components/energy_pdf_report/README.md
+++ b/custom_components/energy_pdf_report/README.md
@@ -19,6 +19,9 @@ Ce composant personnalisé Home Assistant ajoute un service `energy_pdf_report.g
 
 - `dashboard` *(optionnel)* : identifiant ou nom du tableau de bord Énergie à analyser. Si omis, le tableau actif par défaut est utilisé.
 
+- `co2_enabled` *(optionnel)* : booléen permettant d'activer ou de désactiver la section CO₂ pour cet appel. Si le paramètre est absent, la valeur configurée dans les options de l'intégration est utilisée.
+- `price_enabled` *(optionnel)* : booléen permettant d'activer ou de désactiver la section coûts pour cet appel. Si le paramètre est absent, la valeur configurée dans les options de l'intégration est utilisée.
+
 Le fichier généré est également signalé via une notification persistante dans Home Assistant, qui mentionne le tableau de bord utilisé lorsque ce paramètre est précisé.
 
 > ℹ️ Le nombre de statistiques indiqué dans le rapport correspond simplement aux identifiants uniques présents dans vos préférences du tableau de bord Énergie. L'intégration n'impose aucune limite : toutes les statistiques disponibles sont prises en compte.

--- a/custom_components/energy_pdf_report/services.yaml
+++ b/custom_components/energy_pdf_report/services.yaml
@@ -33,3 +33,13 @@ generate:
       name: Tableau de bord énergie
       description: Identifiant ou nom du tableau de bord énergie à utiliser (laisser vide pour le tableau actif par défaut).
       example: maison
+
+    co2_enabled:
+      name: Inclure la section CO₂
+      description: Active l'inclusion des statistiques CO₂ dans le rapport pour cet appel (par défaut la valeur des options est utilisée).
+      example: true
+
+    price_enabled:
+      name: Inclure la section coûts
+      description: Active l'inclusion des statistiques de prix dans le rapport pour cet appel (par défaut la valeur des options est utilisée).
+      example: false


### PR DESCRIPTION
## Summary
- add optional `co2_enabled` and `price_enabled` fields to the service description and validation schema
- let the generate service override configuration defaults for CO₂ and price sections and skip building sensors when disabled
- document the new parameters in the integration README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbc3b3b1b083208f3a0c690e4beb14