### PR TITLE
Fix conclusion summary reset

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1722,7 +1722,6 @@ def _build_pdf(
 
 
 
-    conclusion_summary = None
     if conclusion_summary:
         builder.add_section_title(translations.conclusion_title)
 


### PR DESCRIPTION
## Summary
- remove the stray reassignment that reset `conclusion_summary`
- ensure the conclusion section uses the previously computed summary data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd98211d0832093e345db038eff35