### PR TITLE
Use DejaVu icons for solar and battery categories

### DIFF
--- a/custom_components/energy_pdf_report/pdf.py
+++ b/custom_components/energy_pdf_report/pdf.py
@@ -59,14 +59,14 @@ _CATEGORY_COLORS: Tuple[Tuple[str, Tuple[int, int, int]], ...] = (
 
 _CATEGORY_ICON_HINTS: Tuple[Tuple[str, str], ...] = (
 
-    ("solaire", "🌞"),
+    ("solaire", "☀"),
     ("réseau", "⚡"),
     ("électricité", "⚡"),
     ("consommation", "⚡"),
     ("appareil", "🔌"),
     ("gaz", "🔥"),
     ("eau", "💧"),
-    ("batterie", "🔋"),
+    ("batterie", "⏻"),
     ("co₂", "🌍"),
     ("co2", "🌍"),
     ("coût", "💰"),


### PR DESCRIPTION
## Summary
- replace the solar and battery category icons with DejaVu Sans glyphs so they render in generated PDFs

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68dbe0c410ec83208cdf38fa5486872b