### PR TITLE
Remove cost column from statistics detail table

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1608,7 +1608,7 @@ def _build_pdf(
         metadata,
         cost_mapping,
     )
-    detail_widths = builder.compute_column_widths((0.24, 0.38, 0.16, 0.08, 0.14))
+    detail_widths = builder.compute_column_widths((0.25, 0.51, 0.14, 0.10))
     builder.add_table(
         TableConfig(
             title=translations.detail_table_title,
@@ -1839,11 +1839,11 @@ def _prepare_detail_rows(
     totals: dict[str, float],
     metadata: dict[str, tuple[int, StatisticMetaData]],
     cost_mapping: Mapping[str, str],
-) -> list[tuple[str, str, str, str, str]]:
+) -> list[tuple[str, str, str, str]]:
     """Préparer les lignes détaillées du rapport."""
 
     cost_stats = {value for value in cost_mapping.values() if value}
-    details: list[tuple[str, str, float, str, str]] = []
+    details: list[tuple[str, str, float, str]] = []
     for metric in metrics:
         if metric.statistic_id in cost_stats:
             continue
@@ -1851,19 +1851,13 @@ def _prepare_detail_rows(
         meta_entry = metadata.get(metric.statistic_id)
         name = _extract_name(meta_entry, metric.statistic_id)
         unit = _extract_unit(meta_entry)
-        cost_value = ""
-        cost_statistic = cost_mapping.get(metric.statistic_id)
-        if cost_statistic:
-            cost_total = totals.get(cost_statistic)
-            if cost_total is not None:
-                cost_value = _format_number(cost_total)
-        details.append((metric.category, name, total, unit, cost_value))
+        details.append((metric.category, name, total, unit))
 
     details.sort(key=lambda item: (item[0], -abs(item[2]), item[1]))
 
-    rows: list[tuple[str, str, str, str, str]] = []
-    for category, name, value, unit, cost in details:
-        rows.append((category, name, _format_number(value), unit, cost))
+    rows: list[tuple[str, str, str, str]] = []
+    for category, name, value, unit in details:
+        rows.append((category, name, _format_number(value), unit))
 
     return rows
 

--- a/custom_components/energy_pdf_report/translations.py
+++ b/custom_components/energy_pdf_report/translations.py
@@ -31,7 +31,7 @@ class ReportTranslations:
     detail_title: str
     detail_intro: str
     detail_table_title: str
-    detail_headers: tuple[str, str, str, str, str]
+    detail_headers: tuple[str, str, str, str]
     chart_intro: str
     chart_title: str
     chart_units: str
@@ -94,9 +94,9 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         summary_note_totals="Les totaux correspondent à la variation mesurée dans le tableau de bord énergie sur la période sélectionnée.",
         summary_note_negative="Les valeurs négatives indiquent un flux exporté ou une compensation.",
         detail_title="Analyse par catégorie / source",
-        detail_intro="Chaque statistique suivie est listée avec son énergie et, lorsque disponible, son coût afin de faciliter l'analyse fine par origine ou type de consommation.",
+        detail_intro="Chaque statistique suivie est listée avec son énergie afin de faciliter l'analyse fine par origine ou type de consommation.",
         detail_table_title="Détail des statistiques",
-        detail_headers=("Catégorie", "Statistique", "Total énergie", "Unité", "Coût"),
+        detail_headers=("Catégorie", "Statistique", "Total énergie", "Unité"),
         chart_intro="La visualisation suivante met en avant la répartition des flux pour chaque catégorie suivie et matérialise l'équilibre production / consommation.",
         chart_title="Répartition par catégorie",
         chart_units="Unités : {unit}",
@@ -169,9 +169,9 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         summary_note_totals="Totals correspond to the variation measured in the Energy dashboard over the selected period.",
         summary_note_negative="Negative values indicate exported energy or compensation.",
         detail_title="Breakdown by category/source",
-        detail_intro="Each tracked statistic is listed with its energy and, when available, the related cost to help analyse the data by origin or consumption type.",
+        detail_intro="Each tracked statistic is listed with its energy to help analyse the data by origin or consumption type.",
         detail_table_title="Statistic details",
-        detail_headers=("Category", "Statistic", "Energy total", "Unit", "Cost"),
+        detail_headers=("Category", "Statistic", "Energy total", "Unit"),
         chart_intro="The following chart highlights the distribution of flows per category and illustrates the production versus consumption balance.",
         chart_title="Breakdown by category",
         chart_units="Units: {unit}",
@@ -244,9 +244,9 @@ _TRANSLATIONS: dict[str, ReportTranslations] = {
         summary_note_totals="De totalen komen overeen met de verandering die in het Energiadashboard is gemeten tijdens de geselecteerde periode.",
         summary_note_negative="Negatieve waarden geven geëxporteerde energie of compensatie weer.",
         detail_title="Analyse per categorie / bron",
-        detail_intro="Elke gevolgde statistiek toont het energieverbruik en, indien beschikbaar, de bijbehorende kost zodat je gedetailleerd per oorsprong of verbruikstype kan analyseren.",
+        detail_intro="Elke gevolgde statistiek toont het energieverbruik zodat je gedetailleerd per oorsprong of verbruikstype kan analyseren.",
         detail_table_title="Statistiekdetails",
-        detail_headers=("Categorie", "Statistiek", "Energietotaal", "Eenheid", "Kosten"),
+        detail_headers=("Categorie", "Statistiek", "Energietotaal", "Eenheid"),
         chart_intro="De volgende visualisatie toont de verdeling van de stromen per categorie en beeldt het evenwicht tussen productie en verbruik uit.",
         chart_title="Verdeling per categorie",
         chart_units="Eenheden: {unit}",


### PR DESCRIPTION
## Summary
- drop the cost column from the statistics detail table and reallocate width to the statistic name column
- update translations to reflect the absence of cost information in the detail section

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68dbe677ec008320af5a3c0bacb47b22