### PR TITLE
Increase section spacing in energy PDF

### DIFF
--- a/custom_components/energy_pdf_report/pdf.py
+++ b/custom_components/energy_pdf_report/pdf.py
@@ -31,7 +31,9 @@ BORDER_COLOR = (222, 230, 236)
 ZEBRA_COLORS = ((255, 255, 255), (245, 249, 252))
 TOTAL_FILL_COLOR = (235, 239, 243)
 TOTAL_TEXT_COLOR = (87, 96, 106)
-SECTION_SPACING = 6
+SECTION_SPACING = 9
+SECTION_TITLE_SPACING = 4
+TABLE_BOTTOM_SPACING = 3
 
 CHART_BACKGROUND = (245, 249, 253)
 BAR_TRACK_COLOR = (226, 235, 243)
@@ -279,7 +281,7 @@ class EnergyPDFBuilder:
         self._pdf.set_text_color(*PRIMARY_COLOR)
         self._pdf.set_font(FONT_FAMILY, "B", 15)
         self._pdf.cell(0, 10, text, ln=True)
-        self._pdf.ln(2)
+        self._pdf.ln(SECTION_TITLE_SPACING)
         self._pdf.set_text_color(*self._default_text_color)
 
     def add_paragraph(self, text: str, bold: bool = False, size: int = 11) -> None:
@@ -330,7 +332,7 @@ class EnergyPDFBuilder:
             empty_row = [self._translations.table_empty] + [""] * (len(headers) - 1)
 
             self._draw_row(empty_row, column_widths, row_height, fill=True)
-            self._pdf.ln(1)
+            self._pdf.ln(TABLE_BOTTOM_SPACING)
             return
 
         emphasize = set(config.emphasize_rows or [])
@@ -358,7 +360,7 @@ class EnergyPDFBuilder:
                 font_style=font_style,
             )
 
-        self._pdf.ln(1)
+        self._pdf.ln(TABLE_BOTTOM_SPACING)
         self._pdf.set_text_color(*self._default_text_color)
 
     def add_chart(


### PR DESCRIPTION
## Summary
- increase the default section spacing to provide more breathing room around content blocks
- add dedicated constants to ensure consistent spacing after section titles and tables

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68dbffd3d98483208693ce9fa0c6aa85