### PR TITLE
Add legacy energy_pdf_report compatibility shim

### DIFF
--- a/custom_components/energy_pdf_report/__init__.py
+++ b/custom_components/energy_pdf_report/__init__.py
@@ -1,0 +1,33 @@
+"""Legacy compatibility shim for the Energy PDF Report domain."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from ..ecopilot_pdf_report import (
+    async_setup as ecopilot_async_setup,
+    async_setup_entry as ecopilot_async_setup_entry,
+    async_unload_entry as ecopilot_async_unload_entry,
+)
+from ..ecopilot_pdf_report.const import DOMAIN as ECOPILOT_DOMAIN
+
+DOMAIN = "energy_pdf_report"
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the legacy integration by delegating to the EcoPilot implementation."""
+    return await ecopilot_async_setup(hass, config)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Load a legacy config entry using the EcoPilot implementation."""
+    if entry.domain == DOMAIN and entry.unique_id is None:
+        hass.config_entries.async_update_entry(entry, unique_id=ECOPILOT_DOMAIN)
+    return await ecopilot_async_setup_entry(hass, entry)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a legacy config entry using the EcoPilot implementation."""
+    return await ecopilot_async_unload_entry(hass, entry)

--- a/custom_components/energy_pdf_report/config_flow.py
+++ b/custom_components/energy_pdf_report/config_flow.py
@@ -1,0 +1,33 @@
+"""Legacy config flow that delegates to the EcoPilot implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant import config_entries
+
+from ..ecopilot_pdf_report.config_flow import (
+    EcoPilotPDFReportConfigFlow as EcoPilotConfigFlow,
+    EcoPilotPDFReportOptionsFlowHandler,
+    FlowResult,
+)
+
+DOMAIN = "energy_pdf_report"
+
+
+class EnergyPDFReportConfigFlow(EcoPilotConfigFlow, domain=DOMAIN):
+    """Config flow that keeps the legacy domain available for existing entries."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Abort new installations but keep legacy entries editable."""
+        if not self._async_current_entries():
+            return self.async_abort(reason="integration_migrated")
+        return await super().async_step_user(user_input)
+
+
+async def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+    """Return the EcoPilot options flow handler for legacy entries."""
+    return EcoPilotPDFReportOptionsFlowHandler(config_entry)
+

--- a/custom_components/energy_pdf_report/manifest.json
+++ b/custom_components/energy_pdf_report/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "energy_pdf_report",
+  "name": "Energy PDF Report (Legacy)",
+  "version": "1.0.0",
+  "documentation": "https://github.com/Villersfr2/ecopilot-pdf-report",
+  "issue_tracker": "https://github.com/Villersfr2/ecopilot-pdf-report/issues",
+  "requirements": ["fpdf2>=2.8.4"],
+  "codeowners": ["@Villersfr2"],
+  "config_flow": true,
+  "integration_type": "helper"
+}

--- a/custom_components/energy_pdf_report/translations/en.json
+++ b/custom_components/energy_pdf_report/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "abort": {
+      "integration_migrated": "The Energy PDF Report integration has been replaced by the EcoPilot PDF Reporting Tool. Please remove this entry and install the new integration from HACS."
+    }
+  }
+}

--- a/custom_components/energy_pdf_report/translations/fr.json
+++ b/custom_components/energy_pdf_report/translations/fr.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "abort": {
+      "integration_migrated": "L'intégration Energy PDF Report a été remplacée par EcoPilot PDF Reporting Tool. Veuillez supprimer cette entrée et installer la nouvelle intégration depuis HACS."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight `energy_pdf_report` package that delegates setup to the EcoPilot implementation so legacy entries still load
- expose the EcoPilot options flow handler to the legacy domain and abort new installs with a clear deprecation message
- provide English and French translations for the deprecation notice

## Testing
- python -m compileall custom_components/energy_pdf_report

------
https://chatgpt.com/codex/tasks/task_e_68dd1100981083209f2c867b86e4d1d7